### PR TITLE
RDS2 carrier detection, add RT&AF to FMLIST scan

### DIFF
--- a/src/scanner/redsea.json2csv.sh
+++ b/src/scanner/redsea.json2csv.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 jsonf="$1"
 
 PI="$(  jq ".pi"               "${jsonf}" |grep -v null |sort |uniq -c |sort -nr |head -n 1 |sed -e 's/[^"]*"//' -e 's/"//g' )"
@@ -15,10 +16,29 @@ GRP="$( jq ".group"            "${jsonf}" |grep -v null |sort |uniq -c |sort -nr
 STR="$( jq ".di.stereo"        "${jsonf}" |grep -v null |sort |uniq -c |sort -nr |head -n 1 |sed -e 's/.*true/1/' -e 's/.*false/0/g' )"
 DPT="$( jq ".di.dynamic_pty"   "${jsonf}" |grep -v null |sort |uniq -c |sort -nr |head -n 1 |sed -e 's/.*true/1/' -e 's/.*false/0/g' )"
 OPI="$( jq ".other_network.pi" "${jsonf}" |grep -v null |sort |uniq -c |sort -nr |head -n 1 |sed -e 's/[^"]*"//' -e 's/"//g' )"
+AF="$(jq -c ".partial_alt_frequencies" "${jsonf}" |grep -v null | awk '{ print length($0) " " $0; }' $file | sort -r -n | cut -d ' ' -f 2- | head -n 1 | sed -e 's/\[//g;s/\]//g' | sed -e 's/,/;/g')" # only use longest AF list and replace square brackets and commas, only working with parameter -p in redsea
+longPS="$(jq ".long_ps"        "${jsonf}" |grep -v null |sort |uniq -c |sort -nr |head -n 1 |sed -e 's/[^"]*"/"/' -e 's/,/;/g' )"
+RFTapp="$(jq ".rft.app_name"   "${jsonf}" |grep -v null |sort |uniq -c |sort -nr |head -n 1 |sed -e 's/[^"]*"/"/;s/,/;/g'| sed 's/\"//g' )"
+
+
+
+# check RDS2 and print special message, if no RDS2 found, just return RT
+
+RDS2_stream1="$( jq ".stream"  "${jsonf}" | sort | uniq | grep 1)"
+RDS2_stream2="$( jq ".stream"  "${jsonf}" | sort | uniq | grep 2)"
+RDS2_stream3="$( jq ".stream"  "${jsonf}" | sort | uniq | grep 3)"
+
+if [ ${RDS2_stream1} > 0 ]; then
+    RT="\"Cool! RDS2 Carriers ${RDS2_stream1},${RDS2_stream2},${RDS2_stream3} (${RFTapp}) found!! Check log & report to FMLIST\""
+else
+    RT="$(jq ".partial_radiotext"  "${jsonf}" |grep -v null |sort |uniq -c |sort -nr |head -n 1 |sed -e 's/[^"]*"/"/' -e 's/,/;/g' )" # partial radiotext, only possible with redsea -p parameter 
+if [ "${RT}" = "" ]; then 
+    RT="\"no Radiotext decoded so far\""
+fi
+  fi
 
 if [ "$2" = "debug" ]; then
   echo "PI:${PI},NPI:${NPI},PS:${PS},NPS:${NPS},TA:${TA},TP:${TP},MUSIC:${MSC},PTY:${PTY},GRP:${GRP},STEREO:${STR},DYNPTY:${DPT},OTHER_PI:${OPI},"
 else
-  echo "${PI},${NPI},${PS},${NPS},${TA},${TP},${MSC},${PTY},${GRP},${STR},${DPT},${OPI},,\"allps:\", ${APS},"
+  echo "${PI},${NPI},${PS},${NPS},${TA},${TP},${MSC},${PTY},${GRP},${STR},${DPT},${OPI},,,,,,,${AF},${RT}"
 fi
-

--- a/src/scanner/scanFM.sh
+++ b/src/scanner/scanFM.sh
@@ -365,11 +365,11 @@ cat ${rdy_rec_name}.raw \\
  | csdr fir_decimate_cc $chunk2mpx_dec 2>/dev/null \\
  | csdr fmdemod_quadri_cf \\
  | csdr convert_f_s16 \\
- | redsea --bler --output-hex \\
+ | redsea --streams -p --bler --output-hex \\
  > redsea.\${f}.spy
 
 cat redsea.\${f}.spy \\
- | redsea --input-hex \\
+ | redsea --streams -p --input-hex \\
  > redsea.\${f}.txt
 
 

--- a/src/scanner/scanTest.sh
+++ b/src/scanner/scanTest.sh
@@ -62,9 +62,9 @@ for testNo in $(echo $ARGS); do
 
     "2")
       echo "testing dongle + rtl_fm + redsea .. you should see some JSON text:"
-      echo "rtl_fm -M fm -l 0 -A std -p 0 -s $RDSRATE -F 9 -f $TUNEFREQ | redsea --bler -r $MPXRATE"
+      echo "rtl_fm -M fm -l 0 -A std -p 0 -s $RDSRATE -F 9 -f $TUNEFREQ | redsea -p --streams --bler -r $MPXRATE"
       echo "Press Ctrl+C to abort"
-      rtl_fm -M fm -l 0 -A std -p 0 -s $RDSRATE -F 9 -f $TUNEFREQ | redsea --bler -r $MPXRATE
+      rtl_fm -M fm -l 0 -A std -p 0 -s $RDSRATE -F 9 -f $TUNEFREQ | redsea -p --streams --bler -r $MPXRATE
       ;;
 
     "3")
@@ -100,7 +100,7 @@ for testNo in $(echo $ARGS); do
        | csdr fir_decimate_cc 8 0.125 HAMMING 2>/dev/null \
        | csdr fmdemod_quadri_cf \
        | csdr convert_f_s16 \
-       | redsea --bler -r $MPXRATE
+       | redsea --streams -p --bler -r $MPXRATE
       ;;
 
     "6")
@@ -120,7 +120,7 @@ for testNo in $(echo $ARGS); do
        | csdr fir_decimate_cc 8 0.125 HAMMING \
        | csdr fmdemod_quadri_cf \
        | csdr convert_f_s16 \
-       | redsea --bler -r $MPXRATE
+       | redsea --streams -p --bler -r $MPXRATE
       ;;
 
     *)


### PR DESCRIPTION
Note: redsea > 1.2 required

# changelog

- FMLIST logs now include Radiotext (even partial) and AF (experimentally, the longest AF list will be uploaded, might be buggy with method B)
- `redsea` now checks for RDS2 streams (new parameter `--streams`) and will print the `streams` parameter to the `txt` file
- in case of RDS2 the radiotext line will be replaced by `Cool! RDS2 Carriers ${RDS2_stream1},${RDS2_stream2},${RDS2_stream3} (${RFTapp}) found!! Check log & report to FMLIST` showing the number of streams and the RFT app type (mostly RDS2 logo)
- remove `allps:` from log due to incompatibility with RT and AF
- use `redsea` with `-p` parameter for partial Radiotext, AF (and other fields)